### PR TITLE
Make author field an object for non-asar test builds

### DIFF
--- a/test/fixtures/app-without-asar/resources/app/package.json
+++ b/test/fixtures/app-without-asar/resources/app/package.json
@@ -15,5 +15,9 @@
   "companyName": "Daniel Perez Alvarez",
   "companyUrl": "https://github.com/electron-userland/",
 
-  "author": "Daniel Perez Alvarez <unindented@gmail.com> (https://unindented.org/)"
+  "author": {
+    "name": "Daniel Perez Alvarez",
+    "email": "unindented@gmail.com",
+    "url": "https://unindented.org/"
+  }
 }


### PR DESCRIPTION
This change will implicitly test the author field in package.json for both string and object.