### PR TITLE
Release 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-installer-windows",
   "description": "Create a Windows package for your Electron app.",
-  "version": "1.1.1",
+  "version": "2.0.0",
   "license": "MIT",
   "author": {
     "name": "Daniel Perez Alvarez",


### PR DESCRIPTION
I think it's about time we update all the `electron-installer-...` modules with all the recent changes.
Both `-debian` and `-redhat` are still waiting for one more PR each, and the release of a new `-common` version, before we can publish those, but this module doesn't need anything else.

If this PR gets approved, I will push the `v2.0.0` tag.