### PR TITLE
feat: get nupkg name without glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "debug": "^4.1.1",
     "electron-installer-common": "^0.7.3",
     "fs-extra": "^8.1.0",
-    "glob": "^7.1.4",
     "lodash": "^4.17.15",
     "parse-author": "^2.0.0",
     "which": "^2.0.1",

--- a/src/installer.js
+++ b/src/installer.js
@@ -5,8 +5,6 @@ const debug = require('debug')
 const fs = require('fs-extra')
 const parseAuthor = require('parse-author')
 const path = require('path')
-const { promisify } = require('util')
-const glob = promisify(require('glob'))
 
 const spawn = require('./spawn')
 
@@ -71,12 +69,9 @@ class SquirrelInstaller extends common.ElectronInstaller {
 
     const cmd = path.join(this.vendorDir, 'nuget', 'nuget.exe')
     const args = [
-      'pack',
-      this.specPath,
-      '-BasePath',
-      this.stagingAppDir,
-      '-OutputDirectory',
-      path.join(this.stagingDir, 'nuget'),
+      'pack', this.specPath,
+      '-BasePath', this.stagingAppDir,
+      '-OutputDirectory', path.join(this.stagingDir, 'nuget'),
       '-NoDefaultExcludes'
     ]
 
@@ -93,19 +88,6 @@ class SquirrelInstaller extends common.ElectronInstaller {
     this.options.logger(`Creating spec file at ${this.specPath}`)
 
     return common.wrapError('creating spec file', async () => this.createTemplatedFile(src, this.specPath))
-  }
-
-  /**
-   * Find the package just created.
-   */
-  findPackage () {
-    const packagePattern = path.join(this.stagingDir, 'nuget', '*.nupkg')
-    this.options.logger(`Finding package with pattern ${packagePattern}`)
-
-    return common.wrapError('finding package with pattern', async () => {
-      const files = await glob(packagePattern)
-      return files[0]
-    })
   }
 
   /**
@@ -198,7 +180,7 @@ class SquirrelInstaller extends common.ElectronInstaller {
     }
 
     return common.wrapError('releasifying package', async () => {
-      const pkg = await this.findPackage()
+      const pkg = path.join(this.stagingDir, 'nuget', `${this.options.name}.${this.options.version}.nupkg`)
       args.unshift('--releasify', pkg)
       return spawn(cmd, args, this.options.logger)
     })


### PR DESCRIPTION
CIs were timing out and erroring because the function `findPackage` wasn't labeled as async. This made me realize that we don't need that function since we know the exact name of the created `nupkg`.
This will also remove the dependency on `glob`