### PR TITLE
Nuspec improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,11 +293,11 @@ Default: [`resources/icon.ico`](https://github.com/electron-userland/electron-in
 
 The path to an `.ico` file used for the generated `.exe` installer.
 
-#### options.iconUrl
+#### options.iconNuget
 Type: `String`
 Default: `undefined`
 
-URL for the image to use as the icon for the package in the *Manage NuGet Packages* dialog box, used in the [`iconUrl` field of the `spec` file](https://docs.nuget.org/create/nuspec-reference).
+The path to an image file use as the icon for the NuGet package, used in the [`icon` field of the `spec` file](https://docs.microsoft.com/en-us/nuget/reference/nuspec#icon).
 
 #### options.tags
 Type: `Array[String]`

--- a/README.md
+++ b/README.md
@@ -243,13 +243,7 @@ Relative path to the executable created by Electron Packager. Note that [Electro
 Type: `String`
 Default: `package.description`
 
-Short description of the application, used in the [`summary` field of the `nuspec` file](https://docs.nuget.org/create/nuspec-reference).
-
-#### options.productDescription
-Type: `String`
-Default: `package.productDescription || package.description`
-
-Long description of the application, used in the [`description` field of the `nuspec` file](https://docs.nuget.org/create/nuspec-reference).
+A description of the application, used in the [`description` field of the `nuspec` file](https://docs.microsoft.com/en-us/nuget/reference/nuspec#description).
 
 #### options.version
 Type: `String`

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -3,8 +3,7 @@
   <metadata>
     <% if (name) { %><id><%- name %></id><% } %>
     <% if (productName) { %><title><%- productName %></title><% } %>
-    <% if (description) { %><summary><%- description %></summary><% } %>
-    <% if (productDescription) { %><description><%- productDescription %></description><% } %>
+    <% if (description) { %><description><%- description %></description><% } %>
     <% if (version) { %><version><%- version %></version><% } %>
     <% if (copyright) { %><copyright><%- copyright %></copyright><% } %>
     <% if (authors && authors.length) { %><authors><%- authors.join(', ') %></authors><% } %>

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
-    <% if (name) { %><id><%- name %></id><% } %>
+    <id><%- name %></id>
+    <version><%- version %></version>
+    <description><%- description %></description>
+    <authors><%- authors.join(', ') %></authors>
     <% if (productName) { %><title><%- productName %></title><% } %>
-    <% if (description) { %><description><%- description %></description><% } %>
-    <% if (version) { %><version><%- version %></version><% } %>
     <% if (copyright) { %><copyright><%- copyright %></copyright><% } %>
-    <% if (authors && authors.length) { %><authors><%- authors.join(', ') %></authors><% } %>
-    <% if (owners && owners.length) { %><owners><%- owners.join(', ') %></owners><% } %>
+    <% if (owners) { %><owners><%- owners.join(', ') %></owners><% } %>
     <% if (homepage) { %><projectUrl><%- homepage %></projectUrl><% } %>
-    <% if (iconNuget) { %><icon><%- iconNugetName %></icon><% } %>
     <% if (tags && tags.length) { %><tags><%- tags.join(' ') %></tags><% } %>
+    <% if (iconNuget) { %><icon><%- iconNugetName %></icon><% } %>
   </metadata>
   <files>
     <file src="locales\**" target="lib\net45\locales" />

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -10,7 +10,7 @@
     <% if (authors && authors.length) { %><authors><%- authors.join(', ') %></authors><% } %>
     <% if (owners && owners.length) { %><owners><%- owners.join(', ') %></owners><% } %>
     <% if (homepage) { %><projectUrl><%- homepage %></projectUrl><% } %>
-    <% if (iconUrl) { %><iconUrl><%- iconUrl %></iconUrl><% } %>
+    <% if (iconNuget) { %><icon><%- iconNugetName %></icon><% } %>
     <% if (tags && tags.length) { %><tags><%- tags.join(' ') %></tags><% } %>
   </metadata>
   <files>
@@ -23,5 +23,6 @@
     <file src="icudtl.dat" target="lib\net45\icudtl.dat" />
     <file src="LICENSE" target="lib\net45\LICENSE" />
     <file src="<%- exe %>" target="lib\net45\<%- exe %>" />
+    <% if (iconNuget) { %> <file src="<%- iconNugetName %>" target="" /> <% } %>
   </files>
 </package>

--- a/src/installer.js
+++ b/src/installer.js
@@ -52,6 +52,10 @@ class SquirrelInstaller extends common.ElectronInstaller {
    */
   async copyApplication () {
     await super.copyApplication()
+    if (this.options.iconNuget) {
+      const iconNuget = path.join(this.stagingAppDir, this.options.iconNugetName)
+      await super.copyIcon(this.options.iconNuget, iconNuget)
+    }
     return this.copySquirrelUpdater()
   }
 
@@ -110,7 +114,7 @@ class SquirrelInstaller extends common.ElectronInstaller {
       icon: path.resolve(__dirname, '../resources/icon.ico'),
       animation: path.resolve(__dirname, '../resources/animation.gif'),
 
-      iconUrl: undefined,
+      iconNuget: undefined,
 
       tags: [],
 
@@ -133,6 +137,7 @@ class SquirrelInstaller extends common.ElectronInstaller {
     super.generateOptions()
 
     this.options.name = common.sanitizeName(this.options.name, 'a-zA-Z0-9', '_')
+    if (this.options.iconNuget) this.options.iconNugetName = path.basename(this.options.iconNuget)
 
     if (!this.options.description && !this.options.productDescription) {
       throw new Error("No Description or ProductDescription provided. Please set either a description in the app's package.json or provide it in the this.options.")

--- a/src/installer.js
+++ b/src/installer.js
@@ -139,8 +139,8 @@ class SquirrelInstaller extends common.ElectronInstaller {
     this.options.name = common.sanitizeName(this.options.name, 'a-zA-Z0-9', '_')
     if (this.options.iconNuget) this.options.iconNugetName = path.basename(this.options.iconNuget)
 
-    if (!this.options.description && !this.options.productDescription) {
-      throw new Error("No Description or ProductDescription provided. Please set either a description in the app's package.json or provide it in the this.options.")
+    if (!this.options.description) {
+      throw new Error("No Description provided. Please set a description in the app's package.json or provide it in the this.options.")
     }
 
     if (!this.options.authors) {

--- a/test/installer.js
+++ b/test/installer.js
@@ -8,7 +8,7 @@ describe('module', function () {
   this.timeout(30000)
 
   describeInstaller('with an app with asar', true, {
-    productDescription: 'Just a test.'
+    iconNuget: 'test/fixtures/icon.ico'
   })
 
   describeInstaller('with an app without asar', false, {
@@ -20,11 +20,11 @@ describe('module', function () {
   })
 
   describeInstallerWithException(
-    'with no description or productDescription provided',
+    'with no description provided',
     {
       src: 'test/fixtures/app-without-description-or-product-description/'
     },
-    /^No Description or ProductDescription provided/
+    /^No Description provided/
   )
 
   describeInstallerWithException(
@@ -38,7 +38,6 @@ describe('module', function () {
   // Signing only works on Win32.
   if (process.platform === 'win32') {
     describeInstaller('with a signed app with asar', true, {
-      productDescription: 'Just a test.',
       certificateFile: 'test/fixtures/certificate.pfx',
       certificatePassword: 'test'
     })
@@ -62,12 +61,10 @@ describe('module', function () {
     after(async () => server.closeServer())
 
     describeInstaller('with an app with asar with the same remote release', true, {
-      productDescription: 'Just a test.',
       remoteReleases: 'http://localhost:3000/foo/'
     })
 
     describeInstaller('with an app without asar with an old remote release', false, {
-      productDescription: 'Just a test.',
       remoteReleases: 'http://localhost:3000/bar/'
     })
   })


### PR DESCRIPTION
* Removes deprecated `summary` option and use only `description`. See https://docs.microsoft.com/en-us/nuget/reference/nuspec#summary
* Removes deprecated `iconUrl` option and replace it with `iconNuget`. See https://docs.microsoft.com/en-us/nuget/reference/nuspec#iconurl
* Make `spec.ejs` easier to read by showing the required elements first and without `if` statements
