### PR TITLE
Release version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-installer-windows",
   "description": "Create a Windows package for your Electron app.",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "license": "MIT",
   "author": {
     "name": "Daniel Perez Alvarez",


### PR DESCRIPTION
Here's a possible description of the new release.

https://github.com/electron-userland/electron-installer-windows/compare/v2.0.0...master

---
### Added
- `options.iconNuget` (#307)

### Fixed
- Use `options.productName` as msi description when signing (#308)
- Convert version to semver v1 (#310)

### Changed
- Update Nugget to v5.4.0 (#305)

### Removed
- Node < 10 support (#305)
- Deprecated `options.summary` (#307)
- Deprecated `options.iconUrl` (#307)

---
Once @malept has reviewed and accepted this PR, I'll push the new version tag.