### PR TITLE
feat!: remove node 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'windows-latest']
-        node-version: [10, 12]
+        node-version: [12, 14, 16]
 
     steps:
       - name: Install Linux dependencies

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This tool relies on the awesome [Squirrel.Windows](https://github.com/Squirrel/S
 
 ## Requirements
 
-This tool requires Node 10 or greater.
+This tool requires Node 12 or greater.
 
 I'd recommend building your packages on your target platform, but if you have to run this on Mac OS X or Linux, you will need to install `mono` and `wine` through your package manager.
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "npm run lint && npm run spec"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=12.0.0"
   },
   "dependencies": {
     "@malept/cross-spawn-promise": "^1.0.0",


### PR DESCRIPTION
Also, adds testing for node 14 and 16

BREAKING CHANGE: Requires Node.js v12+